### PR TITLE
Switch to Builder pattern for construction of `WordFilter`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,7 @@ name: Tests
 
 on:
   push:
-    branches: [ master ]
   pull_request:
-    branches: [ master ]
 
 env:
   CARGO_TERM_COLOR: always

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,7 +99,7 @@ use str_overlap::Overlap;
 use utils::debug_unreachable;
 
 /// The strategy a `WordFilter` should use to match repeated characters.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub enum RepeatedCharacterMatchMode {
     /// Allows repeated characters within filtered words.
     ///
@@ -141,7 +141,7 @@ impl Default for RepeatedCharacterMatchMode {
 }
 
 /// The strategy for censoring in a `WordFilter`.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub enum CensorMode {
     /// Replace all matched characters with the character indicated.
     ///
@@ -686,6 +686,7 @@ impl<'a> WordFilter<'a> {
 /// [`aliases`]: Self::aliases
 /// [`repeated_character_match_mode`]: Self::repeated_character_match_mode
 /// [`censor_mode`]: Self::censor_mode
+#[derive(Clone, Debug)]
 pub struct WordFilterBuilder<'a> {
     words: Vec<&'a str>,
     exceptions: Vec<&'a str>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -771,13 +771,6 @@ mod tests {
     use alloc::{vec, vec::Vec};
 
     #[test]
-    fn builder() {
-        let filter = WordFilterBuilder::new().words(&["foo"]).build();
-
-        assert_eq!(filter.find("foo"), vec!["foo"].into_boxed_slice());
-    }
-
-    #[test]
     fn find() {
         let filter = WordFilterBuilder::new().words(&["foo"]).build();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -645,6 +645,47 @@ impl<'a> WordFilter<'a> {
     }
 }
 
+/// A non-consuming builder for a [`WordFilter`].
+///
+/// Allows configuration of any of the following elements that make up a `WordFilter`, through the
+/// corresponding methods:
+///
+/// - **[`words`]** - Words to be filtered.
+/// - **[`exceptions`]** - Words that are not to be filtered.
+/// - **[`separators`]** - Values that may appear between characters of words or exceptions.
+/// - **[`aliases`]** - Pairs of alias strings and source strings. Alias strings may replace source 
+/// strings in words and exceptions.
+/// - **[`repeated_character_match_mode`]** - The [`RepeatedCharacterMatchMode`] to be used. By default
+/// this is set to `RepeatedCharacterMatchMode::AllowRepeatedCharacters`.
+/// - **[`censor_mode`]** - The [`CensorMode`] to be used. By default this is set to
+/// `CensorMode::ReplaceAllWith('*')`.
+///
+/// These methods can be chained on each other, allowing construction to be performed in a single
+/// statement if desired.
+///
+/// # Example
+/// Fully configuring and constructing a `WordFilter` using the `WordFilterBuilder` can be done as
+/// follows:
+///
+/// ```
+/// use word_filter::{CensorMode, RepeatedCharacterMatchMode, WordFilterBuilder};
+///
+/// let filter = WordFilterBuilder::new()
+///     .words(&["foo"])
+///     .exceptions(&["foobar"])
+///     .separators(&[" ", "_"])
+///     .aliases(&[("f", "F")])
+///     .repeated_character_match_mode(RepeatedCharacterMatchMode::DisallowRepeatedCharacters)
+///     .censor_mode(CensorMode::ReplaceAllWith('#'))
+///     .build();
+/// ```
+///
+/// [`words`]: Self::words
+/// [`exceptions`]: Self::exceptions
+/// [`separators`]: Self::separators
+/// [`aliases`]: Self::aliases
+/// [`repeated_character_match_mode`]: Self::repeated_character_match_mode
+/// [`censor_mode`]: Self::censor_mode
 pub struct WordFilterBuilder<'a> {
     words: Vec<&'a str>,
     exceptions: Vec<&'a str>,
@@ -655,6 +696,14 @@ pub struct WordFilterBuilder<'a> {
 }
 
 impl<'a> WordFilterBuilder<'a> {
+    /// Constructs a new `WordFilterBuilder`.
+    ///
+    /// # Example
+    /// ```
+    /// use word_filter::WordFilterBuilder;
+    ///
+    /// let builder = WordFilterBuilder::new();
+    /// ```
     #[inline]
     pub fn new() -> Self {
         Self {
@@ -667,42 +716,123 @@ impl<'a> WordFilterBuilder<'a> {
         }
     }
 
+    /// Adds words to be used in building the [`WordFilter`].
+    ///
+    /// Note that this does not replace any words that have been added prior. Multiple calls to this
+    /// method will result in all words being used.
+    ///
+    /// # Example
+    /// ```
+    /// use word_filter::WordFilterBuilder;
+    ///
+    /// let filter = WordFilterBuilder::new().words(&["foo"]).build();
+    /// ```
     #[inline]
     pub fn words(&mut self, words: &[&'a str]) -> &mut Self {
         self.words.extend_from_slice(words);
         self
     }
 
+    /// Adds exceptions to be used in building the [`WordFilter`].
+    ///
+    /// Note that this does not replace any exceptions that have been added prior. Multiple calls to
+    /// this method will result in all exceptions being used.
+    ///
+    /// # Example
+    /// ```
+    /// use word_filter::WordFilterBuilder;
+    ///
+    /// let filter = WordFilterBuilder::new().exceptions(&["foo"]).build();
+    /// ```
     #[inline]
     pub fn exceptions(&mut self, exceptions: &[&'a str]) -> &mut Self {
         self.exceptions.extend_from_slice(exceptions);
         self
     }
 
+    /// Adds separators to be used in building the [`WordFilter`].
+    ///
+    /// Note that this does not replace any separators that have been added prior. Multiple calls to
+    /// this method will result in all separators being used.
+    ///
+    /// # Example
+    /// ```
+    /// use word_filter::WordFilterBuilder;
+    ///
+    /// let filter = WordFilterBuilder::new().separators(&["_"]).build();
+    /// ```
     #[inline]
     pub fn separators(&mut self, separators: &[&'a str]) -> &mut Self {
         self.separators.extend_from_slice(separators);
         self
     }
 
+    /// Adds aliases to be used in building the [`WordFilter`].
+    ///
+    /// Aliases are tuples defining alias strings that may replace source strings during matching.
+    /// These are of the form `(<source string>, <alias string>)`.
+    ///
+    /// Note that this does not replace any aliases that have been added prior. Multiple calls to
+    /// this method will result in all aliases being used.
+    ///
+    /// # Example
+    /// ```
+    /// use word_filter::WordFilterBuilder;
+    ///
+    /// let filter = WordFilterBuilder::new().aliases(&[("a", "@")]).build();
+    /// ```
     #[inline]
     pub fn aliases(&mut self, aliases: &[(&'a str, &'a str)]) -> &mut Self {
         self.aliases.extend_from_slice(aliases);
         self
     }
 
+    /// Sets the [`RepeatedCharacterMatchMode`] to be used by the [`WordFilter`].
+    ///
+    /// If this is not provided, it will default to
+    /// `RepeatedCharacterMatchMode::AllowRepeatedCharacters`.
+    ///
+    /// # Example
+    /// ```
+    /// use word_filter::{RepeatedCharacterMatchMode, WordFilterBuilder};
+    ///
+    /// let filter = WordFilterBuilder::new()
+    ///     .repeated_character_match_mode(RepeatedCharacterMatchMode::DisallowRepeatedCharacters)
+    ///     .build();
+    /// ```
     #[inline]
     pub fn repeated_character_match_mode(&mut self, mode: RepeatedCharacterMatchMode) -> &mut Self {
         self.repeated_character_match_mode = mode;
         self
     }
 
+    /// Sets the [`CensorMode`] to be used by the [`WordFilter`].
+    ///
+    /// If this is not provided, it will default to `CensorMode::ReplaceAllWith('*')`.
+    ///
+    /// # Example
+    /// ```
+    /// use word_filter::{CensorMode, WordFilterBuilder};
+    ///
+    /// let filter = WordFilterBuilder::new().censor_mode(CensorMode::ReplaceAllWith('#')).build();
+    /// ```
     #[inline]
     pub fn censor_mode(&mut self, mode: CensorMode) -> &mut Self {
         self.censor_mode = mode;
         self
     }
 
+    /// Builds a [`WordFilter`] using the configurations set on the `WordFilterBuilder`.
+    ///
+    /// Note that this is a non-consuming function, and the `WordFilterBuilder` can therefore be
+    /// used after a `WordFilter` is built.
+    ///
+    /// # Example
+    /// ```
+    /// use word_filter::WordFilterBuilder;
+    ///
+    /// let filter = WordFilterBuilder::new().words(&["foo"]).build();
+    /// ```
     #[inline]
     #[must_use]
     pub fn build(&self) -> WordFilter<'a> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,6 +99,7 @@ use str_overlap::Overlap;
 use utils::debug_unreachable;
 
 /// The strategy a `WordFilter` should use to match repeated characters.
+#[derive(Clone, Copy)]
 pub enum RepeatedCharacterMatchMode {
     /// Allows repeated characters within filtered words.
     ///
@@ -140,6 +141,7 @@ impl Default for RepeatedCharacterMatchMode {
 }
 
 /// The strategy for censoring in a `WordFilter`.
+#[derive(Clone, Copy)]
 pub enum CensorMode {
     /// Replace all matched characters with the character indicated.
     ///
@@ -640,6 +642,97 @@ impl<'a> WordFilter<'a> {
         });
 
         output
+    }
+}
+
+pub struct WordFilterBuilder<'a> {
+    words: Vec<&'a str>,
+    exceptions: Vec<&'a str>,
+    separators: Vec<&'a str>,
+    aliases: Vec<(&'a str, &'a str)>,
+    repeated_character_match_mode: RepeatedCharacterMatchMode,
+    censor_mode: CensorMode,
+}
+
+impl<'a> WordFilterBuilder<'a> {
+    #[inline]
+    pub fn new() -> Self {
+        Self {
+            words: Vec::new(),
+            exceptions: Vec::new(),
+            separators: Vec::new(),
+            aliases: Vec::new(),
+            repeated_character_match_mode: RepeatedCharacterMatchMode::AllowRepeatedCharacters,
+            censor_mode: CensorMode::ReplaceAllWith('*'),
+        }
+    }
+
+    #[inline
+]    pub fn word(&mut self, word: &'a str) -> &mut Self {
+        self.words.push(word);
+        self
+    }
+
+    #[inline]
+    pub fn words(&mut self, words: &[&'a str]) -> &mut Self {
+        self.words.extend_from_slice(words);
+        self
+    }
+
+    #[inline]
+    pub fn exception(&mut self, exception: &'a str) -> &mut Self {
+        self.exceptions.push(exception);
+        self
+    }
+
+    #[inline]
+    pub fn exceptions(&mut self, exceptions: &[&'a str]) -> &mut Self {
+        self.exceptions.extend_from_slice(exceptions);
+        self
+    }
+
+    #[inline]
+    pub fn separator(&mut self, separator: &'a str) -> &mut Self {
+        self.separators.push(separator);
+        self
+    }
+
+    #[inline]
+    pub fn separators(&mut self, separators: &[&'a str]) -> &mut Self {
+        self.separators.extend_from_slice(separators);
+        self
+    }
+
+    #[inline]
+    pub fn alias(&mut self, alias: (&'a str, &'a str)) -> &mut Self {
+        self.aliases.push(alias);
+        self
+    }
+
+    #[inline]
+    pub fn aliases(&mut self, aliases: &[(&'a str, &'a str)]) -> &mut Self {
+        self.aliases.extend_from_slice(aliases);
+        self
+    }
+
+    #[inline]
+    pub fn repeated_character_match_mode(&mut self, mode: RepeatedCharacterMatchMode) -> &mut Self {
+        self.repeated_character_match_mode = mode;
+        self
+    }
+
+    #[inline]
+    pub fn censor_mode(&mut self, mode: CensorMode) -> &mut Self {
+        self.censor_mode = mode;
+        self
+    }
+
+    #[inline]
+    pub fn build(&self) -> WordFilter<'a> {
+        WordFilter::new(&self.words, &self.exceptions, &self.separators, &self.aliases, Options {
+            repeated_character_match_mode: self.repeated_character_match_mode,
+            censor_mode: self.censor_mode,
+        })
     }
 }
 


### PR DESCRIPTION
Switches from `WordFilter::new()` to `WordFilterBuilder::new().build()` (i.e. utilizes the builder pattern). This makes creation of `WordFilter`s more straightforward and easier to read. With the old `WordFilter::new()` constructor, the user would have to consult the documentation on every use to remember which slice was which and provide empty slices for inputs they didn't need.