### PR TITLE
Fully embrace graphemes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,6 +53,4 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: actions-rs/tarpaulin@v0.1
-      with:
-        args: --all-features
     - uses: codecov/codecov-action@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ by_address = "1.0.4"
 hashbrown = "0.9.1"
 nested_containment_list = "0.3.0"
 str_overlap = "0.4.3"
-unicode-segmentation = {version = "1.7.1", optional = true}
+unicode-segmentation = "1.7.1"
 
 [dev-dependencies]
 claim = "0.5.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ keywords = ["wordfilter", "word", "filter", "censor", "string"]
 exclude = [".github/*", "clippy.toml"]
 
 [package.metadata.docs.rs]
-all-features = true
 rustdoc-args = ["--html-after-content", "doc/remove_root_module.html"]
 
 [dependencies]

--- a/src/censor.rs
+++ b/src/censor.rs
@@ -10,7 +10,7 @@
 //! ```
 //! use word_filter::{censor, WordFilterBuilder};
 //!
-//! let filter = WordFilterBuilder::new().censor(censor::replace_chars_with!("#")).build();
+//! let filter = WordFilterBuilder::new().censor(censor::replace_graphemes_with!("#")).build();
 //! ```
 //!
 //! Note that if the options here do not suite your use case, you can provide a custom function with
@@ -35,37 +35,6 @@
 pub use alloc::{borrow::ToOwned, string::String};
 #[doc(hidden)]
 pub use unicode_segmentation::UnicodeSegmentation;
-
-/// Creates a censor replacing every character with the given string.
-///
-/// # Example
-/// ```
-/// use word_filter::{censor, WordFilterBuilder};
-///
-/// let filter = WordFilterBuilder::new()
-///     .words(&["foo"])
-///     .censor(censor::replace_chars_with!("#"))
-///     .build();
-///
-/// assert_eq!(filter.censor("foo"), "###");
-/// ```
-#[macro_export]
-macro_rules! _replace_chars_with {
-    ($s:literal) => {
-        |word: &str| {
-            word.chars().fold(
-                $crate::censor::String::with_capacity(word.len()),
-                |mut accumulator, _char| {
-                    accumulator.push_str($s);
-                    accumulator
-                },
-            )
-        }
-    };
-}
-
-#[doc(inline)]
-pub use _replace_chars_with as replace_chars_with;
 
 /// Creates a censor replacing every grapheme with the given string.
 ///
@@ -127,14 +96,7 @@ pub use _replace_words_with as replace_words_with;
 
 #[cfg(test)]
 mod tests {
-    use crate::censor::replace_graphemes_with;
-    use crate::censor::{replace_chars_with, replace_words_with};
-
-    #[test]
-    fn replace_chars() {
-        assert_eq!(replace_chars_with!("#")("foo"), "###");
-        assert_eq!(replace_chars_with!("#")("ã"), "##");
-    }
+    use crate::censor::{replace_graphemes_with, replace_words_with};
 
     #[test]
     fn replace_graphemes() {

--- a/src/censor.rs
+++ b/src/censor.rs
@@ -33,7 +33,6 @@
 
 #[doc(hidden)]
 pub use alloc::{borrow::ToOwned, string::String};
-#[cfg(feature = "unicode-segmentation")]
 #[doc(hidden)]
 pub use unicode_segmentation::UnicodeSegmentation;
 
@@ -81,7 +80,6 @@ pub use _replace_chars_with as replace_chars_with;
 ///
 /// assert_eq!(filter.censor("bãr"), "###");
 /// ```
-#[cfg(feature = "unicode-segmentation")]
 #[macro_export]
 macro_rules! _replace_graphemes_with {
     ($s:literal) => {
@@ -98,7 +96,6 @@ macro_rules! _replace_graphemes_with {
     };
 }
 
-#[cfg(feature = "unicode-segmentation")]
 #[doc(inline)]
 pub use _replace_graphemes_with as replace_graphemes_with;
 
@@ -130,7 +127,6 @@ pub use _replace_words_with as replace_words_with;
 
 #[cfg(test)]
 mod tests {
-    #[cfg(feature = "unicode-segmentation")]
     use crate::censor::replace_graphemes_with;
     use crate::censor::{replace_chars_with, replace_words_with};
 
@@ -140,7 +136,6 @@ mod tests {
         assert_eq!(replace_chars_with!("#")("ã"), "##");
     }
 
-    #[cfg(feature = "unicode-segmentation")]
     #[test]
     fn replace_graphemes() {
         assert_eq!(replace_graphemes_with!("#")("foo"), "###");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,7 +71,7 @@ mod walker;
 pub mod censor;
 
 use alloc::{borrow::ToOwned, boxed::Box, collections::VecDeque, string::String, vec, vec::Vec};
-use censor::replace_chars_with;
+use censor::replace_graphemes_with;
 use core::{
     iter::FromIterator,
     ops::{Bound, RangeBounds},
@@ -152,7 +152,7 @@ impl Default for RepeatedCharacterMatchMode {
 ///     .separators(&[" ", "_"])
 ///     .aliases(&[("f", "F")])
 ///     .repeated_character_match_mode(RepeatedCharacterMatchMode::DisallowRepeatedCharacters)
-///     .censor(censor::replace_chars_with!("#"))
+///     .censor(censor::replace_graphemes_with!("#"))
 ///     .build();
 /// ```
 pub struct WordFilter<'a> {
@@ -432,7 +432,7 @@ impl WordFilter<'_> {
 /// - **[`repeated_character_match_mode`]** - The [`RepeatedCharacterMatchMode`] to be used. By default
 /// this is set to `RepeatedCharacterMatchMode::AllowRepeatedCharacters`.
 /// - **[`censor`]** - The censor to be used. By default this is set to
-/// [`censor::replace_chars_with!("*")`].
+/// [`censor::replace_graphemes_with!("*")`].
 ///
 /// These methods can be chained on each other, allowing construction to be performed in a single
 /// statement if desired.
@@ -450,7 +450,7 @@ impl WordFilter<'_> {
 ///     .separators(&[" ", "_"])
 ///     .aliases(&[("f", "F")])
 ///     .repeated_character_match_mode(RepeatedCharacterMatchMode::DisallowRepeatedCharacters)
-///     .censor(censor::replace_chars_with!("#"))
+///     .censor(censor::replace_graphemes_with!("#"))
 ///     .build();
 /// ```
 ///
@@ -460,7 +460,7 @@ impl WordFilter<'_> {
 /// [`aliases`]: Self::aliases
 /// [`repeated_character_match_mode`]: Self::repeated_character_match_mode
 /// [`censor`]: Self::censor
-/// [`censor::replace_chars_with!("*")`]: censor/macro.replace_chars_with.html
+/// [`censor::replace_graphemes_with!("*")`]: censor/macro.replace_graphemes_with.html
 #[derive(Clone)]
 pub struct WordFilterBuilder<'a> {
     words: Vec<&'a str>,
@@ -489,7 +489,7 @@ impl<'a> WordFilterBuilder<'a> {
             separators: Vec::new(),
             aliases: Vec::new(),
             repeated_character_match_mode: RepeatedCharacterMatchMode::AllowRepeatedCharacters,
-            censor: replace_chars_with!("*"),
+            censor: replace_graphemes_with!("*"),
         }
     }
 
@@ -586,16 +586,16 @@ impl<'a> WordFilterBuilder<'a> {
     /// Sets the censor to be used by the [`WordFilter`].
     ///
     /// A censor is a function mapping from the word to be censored to the censored result. The
-    /// default censor is [`censor::replace_chars_with!("*")`].
+    /// default censor is [`censor::replace_graphemes_with!("*")`].
     ///
     /// # Example
     /// ```
     /// use word_filter::{censor, WordFilterBuilder};
     ///
-    /// let filter = WordFilterBuilder::new().censor(censor::replace_chars_with!("#")).build();
+    /// let filter = WordFilterBuilder::new().censor(censor::replace_graphemes_with!("#")).build();
     /// ```
     ///
-    /// [`censor::replace_chars_with!("*")`]: censor/macro.replace_chars_with.html
+    /// [`censor::replace_graphemes_with!("*")`]: censor/macro.replace_graphemes_with.html
     #[inline]
     pub fn censor(&mut self, censor: fn(&str) -> String) -> &mut Self {
         self.censor = censor;
@@ -763,7 +763,7 @@ impl Default for WordFilterBuilder<'_> {
 
 #[cfg(test)]
 mod tests {
-    use crate::{replace_chars_with, RepeatedCharacterMatchMode, WordFilterBuilder};
+    use crate::{replace_graphemes_with, RepeatedCharacterMatchMode, WordFilterBuilder};
     use alloc::{vec, vec::Vec};
 
     #[test]
@@ -944,7 +944,7 @@ mod tests {
     fn custom_censor() {
         let filter = WordFilterBuilder::new()
             .words(&["foo"])
-            .censor(replace_chars_with!("#"))
+            .censor(replace_graphemes_with!("#"))
             .build();
 
         assert_eq!(filter.censor("foo"), "###");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1000,4 +1000,11 @@ mod tests {
 
         assert_eq!(filter.find("foo baz"), vec!["foobar"].into_boxed_slice());
     }
+
+    #[test]
+    fn repeated_graphemes() {
+        let filter = WordFilterBuilder::new().words(&["bãr"]).build();
+
+        assert_eq!(filter.find("bããr"), vec!["bãr"].into_boxed_slice());
+    }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -10,6 +10,7 @@ use core::hint::unreachable_unchecked;
 ///
 /// # Safety
 /// The caller must make sure this is never run.
+#[track_caller]
 #[allow(clippy::inline_always)]
 #[inline(always)]
 pub(crate) unsafe fn debug_unreachable() -> ! {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -10,7 +10,6 @@ use core::hint::unreachable_unchecked;
 ///
 /// # Safety
 /// The caller must make sure this is never run.
-#[track_caller]
 #[allow(clippy::inline_always)]
 #[inline(always)]
 pub(crate) unsafe fn debug_unreachable() -> ! {

--- a/src/walker.rs
+++ b/src/walker.rs
@@ -187,13 +187,13 @@ impl<'a> Walker<'a> {
         Ok(result.into_iter())
     }
 
-    /// Step the `Walker` along the character `c`.
+    /// Step the `Walker` along the grapheme `g`.
     ///
     /// If successful, returns an iterator of branched `Walker`s.
-    pub(crate) fn step(&mut self, c: char) -> Result<vec::IntoIter<Walker<'a>>, ()> {
+    pub(crate) fn step(&mut self, g: &str) -> Result<vec::IntoIter<Walker<'a>>, ()> {
         let mut branches = Vec::new();
 
-        match self.node.children.get(&c) {
+        match self.node.children.get(g) {
             Some(node) => {
                 match node.node_type {
                     node::Type::Return => {}
@@ -562,10 +562,10 @@ mod tests {
 
         let mut walker = WalkerBuilder::new(&node).build();
 
-        assert_ok!(walker.step('f'));
-        assert_ok!(walker.step('o'));
-        assert_ok!(walker.step('o'));
-        assert_err!(walker.step('o'));
+        assert_ok!(walker.step("f"));
+        assert_ok!(walker.step("o"));
+        assert_ok!(walker.step("o"));
+        assert_err!(walker.step("o"));
     }
 
     #[test]
@@ -575,9 +575,9 @@ mod tests {
 
         let mut walker = WalkerBuilder::new(&node).build();
 
-        assert_ok!(walker.step('f'));
-        assert_ok!(walker.step('o'));
-        assert_ok!(walker.step('o'));
+        assert_ok!(walker.step("f"));
+        assert_ok!(walker.step("o"));
+        assert_ok!(walker.step("o"));
         assert_matches!(walker.status, Status::Match(3, "foo"));
     }
 
@@ -588,9 +588,9 @@ mod tests {
 
         let mut walker = WalkerBuilder::new(&node).build();
 
-        assert_ok!(walker.step('f'));
-        assert_ok!(walker.step('o'));
-        assert_ok!(walker.step('o'));
+        assert_ok!(walker.step("f"));
+        assert_ok!(walker.step("o"));
+        assert_ok!(walker.step("o"));
         assert_matches!(walker.status, Status::Exception(3, "foo"));
     }
 
@@ -604,9 +604,9 @@ mod tests {
             .returns(vec![&return_node])
             .build();
 
-        assert_ok!(walker.step('f'));
-        assert_ok!(walker.step('o'));
-        assert_ok!(walker.step('o'));
+        assert_ok!(walker.step("f"));
+        assert_ok!(walker.step("o"));
+        assert_ok!(walker.step("o"));
         assert!(ptr::eq(walker.node, &return_node));
     }
 
@@ -617,9 +617,9 @@ mod tests {
 
         let mut walker = WalkerBuilder::new(&node).build();
 
-        assert_ok!(walker.step('f'));
-        assert_ok!(walker.step('o'));
-        assert_err!(walker.step('o'));
+        assert_ok!(walker.step("f"));
+        assert_ok!(walker.step("o"));
+        assert_err!(walker.step("o"));
     }
 
     #[test]
@@ -633,9 +633,9 @@ mod tests {
             .returns(vec![&return_node])
             .build();
 
-        assert_ok!(walker.step('f'));
-        assert_ok!(walker.step('o'));
-        assert_ok!(walker.step('o'));
+        assert_ok!(walker.step("f"));
+        assert_ok!(walker.step("o"));
+        assert_ok!(walker.step("o"));
         assert!(ptr::eq(walker.node, &return_node));
         assert_matches!(walker.status, Status::Match(3, ""));
     }
@@ -651,9 +651,9 @@ mod tests {
             .returns(vec![&return_node])
             .build();
 
-        assert_ok!(walker.step('f'));
-        assert_ok!(walker.step('o'));
-        assert_ok!(walker.step('o'));
+        assert_ok!(walker.step("f"));
+        assert_ok!(walker.step("o"));
+        assert_ok!(walker.step("o"));
         assert!(ptr::eq(walker.node, &return_node));
         assert_matches!(walker.status, Status::Exception(3, ""));
     }
@@ -670,9 +670,9 @@ mod tests {
             .returns(vec![&return_node])
             .build();
 
-        assert_ok!(walker.step('f'));
-        assert_ok!(walker.step('o'));
-        assert_ok!(walker.step('o'));
+        assert_ok!(walker.step("f"));
+        assert_ok!(walker.step("o"));
+        assert_ok!(walker.step("o"));
         assert!(ptr::eq(walker.node, &return_node));
         assert!(!walker.in_separator);
         assert_matches!(walker.status, Status::None);
@@ -690,9 +690,9 @@ mod tests {
             .returns(vec![&return_node])
             .build();
 
-        assert_ok!(walker.step('f'));
-        assert_ok!(walker.step('o'));
-        assert_ok!(walker.step('o'));
+        assert_ok!(walker.step("f"));
+        assert_ok!(walker.step("o"));
+        assert_ok!(walker.step("o"));
         assert!(ptr::eq(walker.node, &return_node));
         assert!(!walker.in_separator);
         assert_matches!(walker.status, Status::None);
@@ -710,9 +710,9 @@ mod tests {
             .returns(vec![&return_node_b, &return_node_a])
             .build();
 
-        assert_ok!(walker.step('f'));
-        assert_ok!(walker.step('o'));
-        assert_ok!(walker.step('o'));
+        assert_ok!(walker.step("f"));
+        assert_ok!(walker.step("o"));
+        assert_ok!(walker.step("o"));
         assert!(ptr::eq(walker.node, &return_node_b));
     }
 
@@ -726,12 +726,12 @@ mod tests {
             .callbacks(vec![ContextualizedNode::InDirectPath(&callback_node)])
             .build();
 
-        let branched_walkers = walker.step('f').unwrap().collect::<Vec<_>>();
+        let branched_walkers = walker.step("f").unwrap().collect::<Vec<_>>();
         assert_eq!(branched_walkers.len(), 1);
         assert!(ptr::eq(branched_walkers[0].node, &callback_node));
         match branched_walkers[0].targets[0] {
             ContextualizedNode::InDirectPath(target_node) => {
-                assert!(ptr::eq(target_node, &*node.children[&'f']))
+                assert!(ptr::eq(target_node, &*node.children["f"]))
             }
             _ => unreachable!(),
         }
@@ -749,9 +749,9 @@ mod tests {
             .returns(vec![&return_node])
             .build();
 
-        assert_ok!(walker.step('f'));
-        assert_ok!(walker.step('o'));
-        let branched_walkers = walker.step('o').unwrap().collect::<Vec<_>>();
+        assert_ok!(walker.step("f"));
+        assert_ok!(walker.step("o"));
+        let branched_walkers = walker.step("o").unwrap().collect::<Vec<_>>();
         assert_eq!(branched_walkers.len(), 1);
         assert!(ptr::eq(branched_walkers[0].node, &callback_node));
         match branched_walkers[0].targets[0] {
@@ -768,10 +768,10 @@ mod tests {
         node.add_match("foo");
 
         let mut walker = WalkerBuilder::new(&node)
-            .targets(vec![ContextualizedNode::InDirectPath(&*node.children[&'f'])])
+            .targets(vec![ContextualizedNode::InDirectPath(&*node.children["f"])])
             .build();
 
-        assert_ok!(walker.step('f'));
+        assert_ok!(walker.step("f"));
         assert_eq!(walker.targets.len(), 0);
     }
 
@@ -786,9 +786,9 @@ mod tests {
             .returns(vec![&return_node])
             .build();
 
-        assert_ok!(walker.step('f'));
-        assert_ok!(walker.step('o'));
-        assert_ok!(walker.step('o'));
+        assert_ok!(walker.step("f"));
+        assert_ok!(walker.step("o"));
+        assert_ok!(walker.step("o"));
         assert_eq!(walker.targets.len(), 0);
     }
 
@@ -802,7 +802,7 @@ mod tests {
             .targets(vec![ContextualizedNode::InDirectPath(&target_node)])
             .build();
 
-        assert_err!(walker.step('f'));
+        assert_err!(walker.step("f"));
     }
 
     #[test]
@@ -817,8 +817,8 @@ mod tests {
             .returns(vec![&return_node])
             .build();
 
-        assert_ok!(walker.step('f'));
-        assert_ok!(walker.step('o'));
-        assert_err!(walker.step('o'));
+        assert_ok!(walker.step("f"));
+        assert_ok!(walker.step("o"));
+        assert_err!(walker.step("o"));
     }
 }


### PR DESCRIPTION
Fixes #18. This makes all `Node` connections be based on graphemes instead of chars. It adds `unicode-segmentation` as a required dependency. Ultimately, this is a great change as it promotes the crate acting as users would expect it to act.