### PR TITLE
Grapheme subgraphs.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1031,4 +1031,11 @@ mod tests {
 
         assert_eq!(filter.find("bãr"), vec!["bar"].into_boxed_slice());
     }
+
+    #[test]
+    fn alias_on_grapheme() {
+        let filter = WordFilterBuilder::new().words(&["bãr"]).aliases(&[("ã", "õ")]).build();
+
+        assert_eq!(filter.find("bõr"), vec!["bãr"].into_boxed_slice());
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -207,7 +207,9 @@ impl WordFilter<'_> {
                             separator_walker
                                 .callbacks
                                 .push(ContextualizedNode::InSubgraph(walker.node));
-                            separator_walker.targets.push(ContextualizedNode::InSubgraph(walker.node));
+                            separator_walker
+                                .targets
+                                .push(ContextualizedNode::InSubgraph(walker.node));
                             separator_walker
                         }));
                         new_walkers.extend(branches);
@@ -228,7 +230,8 @@ impl WordFilter<'_> {
                         }
 
                         // Graphemes.
-                        let grapheme_walkers = walker.branch_to_grapheme_subgraphs(&mut HashSet::new());
+                        let grapheme_walkers =
+                            walker.branch_to_grapheme_subgraphs(&mut HashSet::new());
                         if let RepeatedCharacterMatchMode::AllowRepeatedCharacters =
                             self.repeated_character_match_mode
                         {
@@ -253,7 +256,9 @@ impl WordFilter<'_> {
                             separator_walker
                                 .callbacks
                                 .push(ContextualizedNode::InSubgraph(walker.node));
-                            separator_walker.targets.push(ContextualizedNode::InSubgraph(walker.node));
+                            separator_walker
+                                .targets
+                                .push(ContextualizedNode::InSubgraph(walker.node));
                         }
                         new_walkers.push(separator_walker);
 
@@ -1019,7 +1024,10 @@ mod tests {
 
     #[test]
     fn grapheme_in_alias() {
-        let filter = WordFilterBuilder::new().words(&["bar"]).aliases(&[("a", "ã")]).build();
+        let filter = WordFilterBuilder::new()
+            .words(&["bar"])
+            .aliases(&[("a", "ã")])
+            .build();
 
         assert_eq!(filter.find("bãr"), vec!["bar"].into_boxed_slice());
     }

--- a/src/node.rs
+++ b/src/node.rs
@@ -304,7 +304,16 @@ impl fmt::Debug for Node<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Node")
             .field("children", &self.children)
-            .field("aliases", &self.aliases.iter().map(|(subgraph_node, return_node)| (*subgraph_node as *const Node, *return_node as *const Node)).collect::<Vec<_>>())
+            .field(
+                "aliases",
+                &self
+                    .aliases
+                    .iter()
+                    .map(|(subgraph_node, return_node)| {
+                        (*subgraph_node as *const Node, *return_node as *const Node)
+                    })
+                    .collect::<Vec<_>>(),
+            )
             .field("node_type", &self.node_type)
             .field("grapheme_subgraphs", &self.grapheme_subgraphs)
             .finish()


### PR DESCRIPTION
Fixes #20. This introduces grapheme subgraphs, which are inserted into graphs when multi-character graphemes are encountered. This allows for repeated character matching to take graphemes into account. while also matching on a per-character basis.