### PR TITLE
Add support for inclusive separators.

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -184,3 +184,8 @@ fn grapheme_at_root() {
         vec!["ãbc"]
     );
 }
+
+#[test]
+fn censor_combining_separator() {
+    assert_eq!(COMBINING_SEPARATOR.censor("foõ"), "***");
+}

--- a/tests/integration_codegen/build.rs
+++ b/tests/integration_codegen/build.rs
@@ -21,7 +21,7 @@ fn main() {
 
     writeln!(
         &mut file,
-        "{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}",
+        "{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}",
         foo_generator.generate("WORD"),
         foo_generator.clone().word("bar").generate("MULTIPLE_WORDS"),
         foo_generator
@@ -88,6 +88,10 @@ fn main() {
             .clone()
             .word("ãbc")
             .generate("GRAPHEME_AT_ROOT"),
+        foo_generator
+            .clone()
+            .inclusive_separator('\u{303}')
+            .generate("COMBINING_SEPARATOR"),
     )
     .unwrap();
 }

--- a/word_filter_codegen/src/lib.rs
+++ b/word_filter_codegen/src/lib.rs
@@ -144,6 +144,7 @@ pub struct WordFilterGenerator {
     words: Vec<String>,
     exceptions: Vec<String>,
     separators: Vec<String>,
+    inclusive_separators: Vec<String>,
     aliases: Vec<(String, String)>,
     visibility: Visibility,
     doc: String,
@@ -276,6 +277,49 @@ impl WordFilterGenerator {
     {
         self.separators
             .extend(separators.into_iter().map(|s| s.to_string()));
+        self
+    }
+
+    /// Add a single inclusive separator.
+    ///
+    /// An inclusive separator is a separator that will be included at the end of matched words or
+    /// exceptions (as opposed to separators, which are not included at the end of matches).
+    ///
+    /// # Example
+    /// ```
+    /// use word_filter_codegen::WordFilterGenerator;
+    ///
+    /// let mut generator = WordFilterGenerator::new();
+    /// generator.inclusive_separator('\u{303}');
+    /// ```
+    #[inline]
+    pub fn inclusive_separator<S>(&mut self, inclusive_separator: S) -> &mut Self
+    where
+        S: ToString,
+    {
+        self.inclusive_separators.push(inclusive_separator.to_string());
+        self
+    }
+
+    /// Add inclusive separators.
+    ///
+    /// An inclusive separator is a separator that will be included at the end of matched words or
+    /// exceptions (as opposed to separators, which are not included at the end of matches).
+    ///
+    /// # Example
+    /// ```
+    /// use word_filter_codegen::WordFilterGenerator;
+    ///
+    /// let mut generator = WordFilterGenerator::new();
+    /// generator.inclusive_separators(&['\u{303}', '\u{304}']);
+    #[inline]
+    pub fn inclusive_separators<I, S>(&mut self, inclusive_separators: I) -> &mut Self
+    where
+        I: IntoIterator<Item = S>,
+        S: ToString,
+    {
+        self.inclusive_separators
+            .extend(inclusive_separators.into_iter().map(|s| s.to_string()));
         self
     }
 
@@ -415,6 +459,9 @@ impl WordFilterGenerator {
         }
         for separator in &self.separators {
             pda.add_separator(separator);
+        }
+        for inclusive_separator in &self.inclusive_separators {
+            pda.add_inclusive_separator(inclusive_separator);
         }
 
         let mut aliases = self.aliases.clone();

--- a/word_filter_codegen/src/pda.rs
+++ b/word_filter_codegen/src/pda.rs
@@ -162,6 +162,34 @@ impl<'a> Pda<'a> {
         self.add_separator_internal(s, SEPARATOR_INDEX)
     }
 
+    /// Add inclusive separator states using input `s`.
+    fn add_inclusive_separator_internal(&mut self, s: &str, index: usize) {
+        let mut chars = s.chars();
+        let c = match chars.next() {
+            Some(c) => c,
+            None => {
+                self.states[index].r#type = Type::Return;
+                return;
+            }
+        };
+        let new_index = match self.states[index].c_transitions.get(&c) {
+            Some(new_index) => *new_index,
+            None => {
+                let new_index = self.states.len();
+                self.states.push(State::default());
+                self.states[index].c_transitions.insert(c, new_index);
+                new_index
+            }
+        };
+
+        self.add_inclusive_separator_internal(chars.as_str(), new_index)
+    }
+
+    /// Add an inclusive separator.
+    pub(crate) fn add_inclusive_separator(&mut self, s: &str) {
+        self.add_inclusive_separator_internal(s, SEPARATOR_INDEX);
+    }
+
     /// Create a new alias, returning the index of the alias's entry state.
     pub(crate) fn initialize_alias(&mut self, s: &str) -> usize {
         let new_index = self.states.len();

--- a/word_filter_codegen/tests/trybuild.rs
+++ b/word_filter_codegen/tests/trybuild.rs
@@ -63,6 +63,8 @@ compiles!(
     separators,
     WordFilterGenerator::new().separators(&["foo", "bar"])
 );
+compiles!(inclusive_separator, WordFilterGenerator::new().inclusive_separator('\u{303}'));
+compiles!(inclusive_separators, WordFilterGenerator::new().inclusive_separators('\u{300}'..='\u{304}'));
 compiles!(alias, WordFilterGenerator::new().alias("foo", "bar"));
 compiles!(
     aliases,


### PR DESCRIPTION
Adds support for inclusive separators, which don't push an `AppendedSeparator` stack value after returning.

Fixes #41.