### PR TITLE
Separator state type

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,8 +128,8 @@ impl<'a, const N: usize> WordFilter<'a, N> {
             ids.extend(self.spawn_entry_ids(index));
             for c in grapheme.chars() {
                 let mut new_ids = Vec::new();
-                for instant in ids.drain(..) {
-                    new_ids.extend(instant.step(c));
+                for id in ids.drain(..) {
+                    new_ids.extend(id.step(c, first_c && chars.clone().next().is_none()));
                 }
                 index += 1;
                 ids = new_ids;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,18 +126,25 @@ impl<'a, const N: usize> WordFilter<'a, N> {
         // graphemes are kept.
         for grapheme in input.graphemes(true) {
             ids.extend(self.spawn_entry_ids(index));
+            let mut first_c = true;
             for c in grapheme.chars() {
                 let mut new_ids = Vec::new();
                 for id in ids.drain(..) {
-                    new_ids.extend(id.step(c, first_c && chars.clone().next().is_none()));
+                    new_ids.extend(id.step(c, first_c));
                 }
                 index += 1;
                 ids = new_ids;
+                first_c = false;
             }
             // Now that all characters within the grapheme have been processed, determine if any
             // ids are in an accepting state.
             for id in &ids {
                 if id.is_accepting() {
+                    extern crate std;
+                    use core::ops::RangeBounds;
+                    std::dbg!(&id.state.r#type);
+                    std::dbg!(&id.start_bound());
+                    std::dbg!(&id.end_bound());
                     accepted_ids.push(id.clone());
                 }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,11 +140,6 @@ impl<'a, const N: usize> WordFilter<'a, N> {
             // ids are in an accepting state.
             for id in &ids {
                 if id.is_accepting() {
-                    extern crate std;
-                    use core::ops::RangeBounds;
-                    std::dbg!(&id.state.r#type);
-                    std::dbg!(&id.start_bound());
-                    std::dbg!(&id.end_bound());
                     accepted_ids.push(id.clone());
                 }
             }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -184,3 +184,13 @@ fn grapheme_at_root() {
         vec!["ãbc"]
     );
 }
+
+#[test]
+fn censor_combining_separator() {
+    assert_eq!(COMBINING_SEPARATOR.censor("foõ"), "***");
+}
+
+#[test]
+fn do_not_censor_combining_separator_on_other_separator() {
+    assert_eq!(COMBINING_SEPARATOR.censor("foo \u{303}"), "*** \u{303}");
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -204,3 +204,8 @@ fn censor_combining_separator_after_match() {
 fn do_not_censor_combining_separator_on_other_separator() {
     assert_eq!(COMBINING_SEPARATOR.censor("foo \u{303}"), "*** \u{303}");
 }
+
+#[test]
+fn repetition_does_not_match_word() {
+    assert_eq!(EXCEPTION.censor("foob"), "***b");
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -191,6 +191,11 @@ fn censor_combining_separator() {
 }
 
 #[test]
+fn censor_combining_separator_after_repetition() {
+    assert_eq!(COMBINING_SEPARATOR.censor("fooõ"), "****");
+}
+
+#[test]
 fn do_not_censor_combining_separator_on_other_separator() {
     assert_eq!(COMBINING_SEPARATOR.censor("foo \u{303}"), "*** \u{303}");
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -196,6 +196,11 @@ fn censor_combining_separator_after_repetition() {
 }
 
 #[test]
+fn censor_combining_separator_after_match() {
+    assert_eq!(COMBINING_SEPARATOR.censor("foo foõ"), "*** ***");
+}
+
+#[test]
 fn do_not_censor_combining_separator_on_other_separator() {
     assert_eq!(COMBINING_SEPARATOR.censor("foo \u{303}"), "*** \u{303}");
 }

--- a/tests/integration_codegen/build.rs
+++ b/tests/integration_codegen/build.rs
@@ -21,7 +21,7 @@ fn main() {
 
     writeln!(
         &mut file,
-        "{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}",
+        "{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}",
         foo_generator.generate("WORD"),
         foo_generator.clone().word("bar").generate("MULTIPLE_WORDS"),
         foo_generator
@@ -88,6 +88,10 @@ fn main() {
             .clone()
             .word("ãbc")
             .generate("GRAPHEME_AT_ROOT"),
+        foo_generator
+            .clone()
+            .separators(&[' ', '\u{303}'])
+            .generate("COMBINING_SEPARATOR"),
     )
     .unwrap();
 }

--- a/word_filter_codegen/src/pda.rs
+++ b/word_filter_codegen/src/pda.rs
@@ -25,7 +25,10 @@ impl<'a> Pda<'a> {
         Self {
             states: vec![
                 State::default(),
-                State::default(),
+                State {
+                    r#type: Type::Separator,
+                    ..Default::default()
+                },
                 State {
                     r#type: Type::SeparatorReturn,
                     ..Default::default()
@@ -148,7 +151,10 @@ impl<'a> Pda<'a> {
             (_, Some(new_index)) => *new_index,
             _ => {
                 let new_index = self.states.len();
-                self.states.push(State::default());
+                self.states.push(State {
+                    r#type: Type::Separator,
+                    ..Default::default()
+                });
                 self.states[index].c_transitions.insert(c, new_index);
                 new_index
             }

--- a/word_filter_codegen/src/type.rs
+++ b/word_filter_codegen/src/type.rs
@@ -8,6 +8,7 @@ pub(crate) enum Type<'a> {
     None,
     Word(&'a str),
     Exception,
+    Separator,
     Return,
     SeparatorReturn,
 }
@@ -19,6 +20,7 @@ impl Type<'_> {
             Type::None => "::word_filter::pda::Type::None".to_owned(),
             Type::Word(s) => format!("::word_filter::pda::Type::Word(\"{}\")", s),
             Type::Exception => "::word_filter::pda::Type::Exception".to_owned(),
+            Type::Separator => "::word_filter::pda::Type::Separator".to_owned(),
             Type::Return => "::word_filter::pda::Type::Return".to_owned(),
             Type::SeparatorReturn => "::word_filter::pda::Type::SeparatorReturn".to_owned(),
         }


### PR DESCRIPTION
This PR switches from pushing the AppendedSeparator value to the stack to using a Separator state type to identify whether computation is within a separator.

This is preferable to #47, since it doesn't require any differentiation by the user between different types of separators. Plus, this passes some edge cases that #47 doesn't.

Fixes #41 and #48.