### PR TITLE
State Minimization

### DIFF
--- a/word_filter_codegen/Cargo.toml
+++ b/word_filter_codegen/Cargo.toml
@@ -12,6 +12,7 @@ keywords = ["wordfilter", "word", "filter", "censor", "string"]
 include = ["/src/**/*", "/LICENSE-*", "/build.rs", "/README.md"]
 
 [dependencies]
+hashbrown = "0.11.2"
 new_debug_unreachable = "1.0.4"
 str_overlap = "0.4.3"
 unicode-segmentation = "1.7.1"

--- a/word_filter_codegen/src/lib.rs
+++ b/word_filter_codegen/src/lib.rs
@@ -478,6 +478,8 @@ impl WordFilterGenerator {
             pda.add_alias(&value, index, 0, &mut BTreeSet::new());
         }
 
+        pda.minimize();
+
         format!(
             "#[doc = \"{}\"]
             {} static {}: {} = {};",

--- a/word_filter_codegen/src/pda.rs
+++ b/word_filter_codegen/src/pda.rs
@@ -235,7 +235,7 @@ impl<'a> Pda<'a> {
     pub(crate) fn minimize(&mut self) {
         loop {
             // Find the set of all distinct and duplicated states. The distinct states will be
-            // kept. 
+            // kept.
             let mut distinct_states = HashMap::new();
             // Note that deleted_states will always be ordered from least to greatest.
             let mut deleted_states = Vec::new();

--- a/word_filter_codegen/src/state.rs
+++ b/word_filter_codegen/src/state.rs
@@ -12,7 +12,7 @@ use alloc::{
 const SEPARATOR_INDEX: usize = 1;
 
 /// Push-down automaton state code generator.
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default, Eq, Hash, PartialEq)]
 pub(crate) struct State<'a> {
     pub(crate) r#type: Type<'a>,
     pub(crate) c_transitions: BTreeMap<char, usize>,

--- a/word_filter_codegen/src/type.rs
+++ b/word_filter_codegen/src/type.rs
@@ -3,7 +3,7 @@
 use alloc::{borrow::ToOwned, format, string::String};
 
 /// Code generator for a state's type.
-#[derive(Debug)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub(crate) enum Type<'a> {
     None,
     Word(&'a str),


### PR DESCRIPTION
Fixes #40.

This is a naive algorithm to minimize the states during codegen. It combines states that have the same fields (by storing within a hashmap), doing so in a repeated loop until no more duplicated states are found.

This lengthens compile times a bit, but not too significantly that it's unbearable. Compile times are already kinda long anyway. Plus, I suspect that the times will go back down with #52.