### PR TITLE
Stop storing separator state in states that can enter separator.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,7 +113,7 @@ impl<'a, const N: usize> WordFilter<'a, N> {
         start: usize,
     ) -> impl Iterator<Item = InstantaneousDescription<'_>> {
         let mut ids = vec![InstantaneousDescription::new(&self.states[0], start)];
-        ids.extend(ids[0].transition(None, &mut HashSet::new()));
+        ids.extend(ids[0].transition(None, &self.states[1], &mut HashSet::new()));
         ids.into_iter()
     }
 
@@ -130,7 +130,7 @@ impl<'a, const N: usize> WordFilter<'a, N> {
             for c in grapheme.chars() {
                 let mut new_ids = Vec::new();
                 for id in ids.drain(..) {
-                    new_ids.extend(id.step(c, first_c));
+                    new_ids.extend(id.step(c, &self.states[1], first_c));
                 }
                 index += 1;
                 ids = new_ids;

--- a/src/pda.rs
+++ b/src/pda.rs
@@ -126,7 +126,12 @@ impl<'a> State<'a> {
     ///
     /// To perform an ε-transition, a `None` value should be provided for the parameter `c`.
     #[inline]
-    fn transitions(&'a self, c: Option<char>, s: stack::Value<'a>, separator: &'a State<'a>) -> Vec<Transition<'a>> {
+    fn transitions(
+        &'a self,
+        c: Option<char>,
+        s: stack::Value<'a>,
+        separator: &'a State<'a>,
+    ) -> Vec<Transition<'a>> {
         let mut result = Vec::new();
 
         if let stack::Value::Target(target_state) = s {
@@ -311,7 +316,11 @@ impl<'a> InstantaneousDescription<'a> {
         let mut new_ids = Vec::new();
         for transition in self
             .state
-            .transitions(c, self.stack.last().unwrap_or(&stack::Value::None).clone(), separator)
+            .transitions(
+                c,
+                self.stack.last().unwrap_or(&stack::Value::None).clone(),
+                separator,
+            )
             .iter()
         {
             if !visited.contains(&ByAddress(transition.state)) {

--- a/word_filter_codegen/src/state.rs
+++ b/word_filter_codegen/src/state.rs
@@ -9,8 +9,6 @@ use alloc::{
     vec::Vec,
 };
 
-const SEPARATOR_INDEX: usize = 1;
-
 /// Push-down automaton state code generator.
 #[derive(Clone, Debug, Default, Eq, Hash, PartialEq)]
 pub(crate) struct State<'a> {
@@ -29,14 +27,14 @@ impl State<'_> {
             "::word_filter::pda::State {{
                 r#type: {},
                 c_transitions: {},
-                separator: {},
+                into_separator: {},
                 repetition: {},
                 aliases: {},
                 graphemes: {},
             }}",
             self.r#type.to_definition(),
             self.define_c_transition_function(identifier),
-            self.define_separator(identifier),
+            self.into_separator,
             self.define_repetition(identifier),
             self.define_aliases(identifier),
             self.define_graphemes(identifier),
@@ -68,15 +66,6 @@ impl State<'_> {
             identifier,
             index
         )
-    }
-
-    /// Define the separator field.
-    fn define_separator(&self, identifier: &str) -> String {
-        if self.into_separator {
-            format!("Some(&{}.states[{}])", identifier, SEPARATOR_INDEX)
-        } else {
-            "None".to_owned()
-        }
     }
 
     /// Define the repetition transition field.


### PR DESCRIPTION
Fixes #54.

Changes states  `separator` field to an `into_separator` field, which is simply a boolean. The separator node is passed during computation instead.