### PR TITLE
Stop storing repetition state

### DIFF
--- a/src/pda.rs
+++ b/src/pda.rs
@@ -102,11 +102,6 @@ pub struct State<'a> {
     ///
     /// Each character can only transition to one other state directly.
     pub c_transitions: fn(char) -> Option<&'a State<'a>>,
-    /// A possible repetition transition.
-    ///
-    /// When transitioning along this character, computation can return back to the previous state
-    /// that is stored here.
-    pub repetition: Option<&'a State<'a>>,
     /// Whether the state can be repeated to.
     pub into_repetition: bool,
     /// Whether the state can process a repetition on the stack.
@@ -419,7 +414,7 @@ impl<'a> InstantaneousDescription<'a> {
             )
             .iter()
         {
-            if !visited.contains(&ByAddress(transition.state)) {
+            if !visited.contains(&ByAddress(transition.state)) || matches!(transition.state.r#type, Type::Return) {
                 let mut new_id = self.clone();
                 new_id.state = transition.state;
                 for manipulation in &transition.stack_manipulations {

--- a/src/pda.rs
+++ b/src/pda.rs
@@ -66,6 +66,7 @@ mod stack {
         /// States stored here must be hit before they are popped. These are pushed in repetition
         /// handling to ensure the same path is repeated.
         Target(&'a State<'a>),
+        Repetition(&'a State<'a>),
     }
 
     /// Defines a manipulation of the stack.
@@ -106,6 +107,10 @@ pub struct State<'a> {
     /// When transitioning along this character, computation can return back to the previous state
     /// that is stored here.
     pub repetition: Option<&'a State<'a>>,
+    /// Whether the state can be repeated to.
+    pub into_repetition: bool,
+    /// Whether the state can process a repetition on the stack.
+    pub take_repetition: bool,
     /// Whether the separator state can be entered from this state.
     pub into_separator: bool,
     /// Alias states and their accompanying return states.
@@ -134,87 +139,178 @@ impl<'a> State<'a> {
     ) -> Vec<Transition<'a>> {
         let mut result = Vec::new();
 
-        if let stack::Value::Target(target_state) = s {
-            match c {
-                Some(c) => {
-                    if let Some(state) = (self.c_transitions)(c) {
-                        if state.repetition.is_some() {
-                            if ptr::eq(state, target_state) {
+        match s {
+            stack::Value::Repetition(repetition_state) => {
+                match c {
+                    Some(c) => {
+                        if !self.take_repetition {
+                            if let Some(state) = (self.c_transitions)(c) {
                                 result.push(Transition {
                                     state,
-                                    stack_manipulations: vec![stack::Manipulation::Pop],
-                                })
+                                    stack_manipulations: vec![],
+                                });
+                                if self.into_repetition {
+                                    result.push(Transition {
+                                        state,
+                                        stack_manipulations: vec![stack::Manipulation::Push(stack::Value::Repetition(self))],
+                                    });
+                                }
                             }
-                        } else {
-                            result.push(Transition {
-                                state,
-                                stack_manipulations: vec![],
-                            })
                         }
                     }
-                }
-                None => {
-                    for alias in self.aliases {
-                        if ptr::eq(alias.1, target_state) {
+                    None => {
+                        if self.into_separator {
                             result.push(Transition {
-                                state: alias.0,
-                                stack_manipulations: vec![
-                                    stack::Manipulation::Pop,
-                                    stack::Manipulation::Push(stack::Value::Return(alias.1)),
-                                ],
+                                state: separator,
+                                stack_manipulations: vec![stack::Manipulation::Push(
+                                    stack::Value::Return(self),
+                                )],
+                            });
+                        }
+                        if self.take_repetition {
+                            // Take the repetition.
+                            result.push(Transition {
+                                state: repetition_state,
+                                stack_manipulations: vec![stack::Manipulation::Pop, stack::Manipulation::Push(stack::Value::Target(self))],
                             })
+                        } else {
+                            for alias in self.aliases {
+                                result.push(Transition {
+                                    state: alias.0,
+                                    stack_manipulations: vec![stack::Manipulation::Push(
+                                        stack::Value::Return(alias.1),
+                                    )],
+                                });
+                                if self.into_repetition {
+                                    result.push(Transition {
+                                        state: alias.0,
+                                        stack_manipulations: vec![stack::Manipulation::Push(stack::Value::Repetition(self)), stack::Manipulation::Push(stack::Value::Return(alias.1))],
+                                    })
+                                }
+                            }
+                            for grapheme in self.graphemes {
+                                result.push(Transition {
+                                    state: grapheme,
+                                    stack_manipulations: vec![],
+                                });
+                            }
                         }
                     }
                 }
             }
-        } else {
-            match c {
-                Some(c) => {
-                    if let Some(state) = (self.c_transitions)(c) {
-                        result.push(Transition {
-                            state,
-                            stack_manipulations: vec![],
-                        })
+            stack::Value::Target(target_state) => {
+                match c {
+                    Some(c) => {
+                        if let Some(state) = (self.c_transitions)(c) {
+                            if state.take_repetition {
+                                if ptr::eq(state, target_state) {
+                                    result.push(Transition {
+                                        state,
+                                        stack_manipulations: vec![stack::Manipulation::Pop],
+                                    });
+                                    if self.into_repetition {
+                                        result.push(Transition {
+                                            state,
+                                            stack_manipulations: vec![stack::Manipulation::Pop, stack::Manipulation::Push(stack::Value::Repetition(self))],
+                                        });
+                                    }
+                                }
+                            } else {
+                                result.push(Transition {
+                                    state,
+                                    stack_manipulations: vec![],
+                                });
+                                if self.into_repetition {
+                                    result.push(Transition {
+                                        state,
+                                        stack_manipulations: vec![stack::Manipulation::Push(stack::Value::Repetition(self))],
+                                    });
+                                }
+                            }
+                        }
+                    }
+                    None => {
+                        for alias in self.aliases {
+                            if ptr::eq(alias.1, target_state) {
+                                result.push(Transition {
+                                    state: alias.0,
+                                    stack_manipulations: vec![
+                                        stack::Manipulation::Pop,
+                                        stack::Manipulation::Push(stack::Value::Return(alias.1)),
+                                    ],
+                                });
+                                if self.into_repetition {
+                                    result.push(Transition {
+                                        state: alias.0,
+                                        stack_manipulations: vec![
+                                            stack::Manipulation::Pop,
+                                            stack::Manipulation::Push(stack::Value::Repetition(self)),
+                                            stack::Manipulation::Push(stack::Value::Return(alias.1)),
+                                        ],
+                                    });
+                                }
+                            }
+                        }
                     }
                 }
-                None => {
-                    if self.into_separator {
-                        result.push(Transition {
-                            state: separator,
-                            stack_manipulations: vec![stack::Manipulation::Push(
-                                stack::Value::Return(self),
-                            )],
-                        });
-                    }
-                    for alias in self.aliases {
-                        result.push(Transition {
-                            state: alias.0,
-                            stack_manipulations: vec![stack::Manipulation::Push(
-                                stack::Value::Return(alias.1),
-                            )],
-                        });
-                    }
-                    for grapheme in self.graphemes {
-                        result.push(Transition {
-                            state: grapheme,
-                            stack_manipulations: vec![],
-                        });
-                    }
-                    if let Some(reptition) = self.repetition {
-                        result.push(Transition {
-                            state: reptition,
-                            stack_manipulations: vec![stack::Manipulation::Push(
-                                stack::Value::Target(self),
-                            )],
-                        });
-                    }
-
-                    if matches!(self.r#type, Type::Return | Type::SeparatorReturn) {
-                        if let stack::Value::Return(state) = s {
+            }
+            _ => {
+                match c {
+                    Some(c) => {
+                        if let Some(state) = (self.c_transitions)(c) {
                             result.push(Transition {
                                 state,
-                                stack_manipulations: vec![stack::Manipulation::Pop],
+                                stack_manipulations: vec![],
                             });
+                            if self.into_repetition {
+                                result.push(Transition {
+                                    state,
+                                    stack_manipulations: vec![stack::Manipulation::Push(stack::Value::Repetition(self))],
+                                });
+                            }
+                        }
+                    }
+                    None => {
+                        if self.into_separator {
+                            result.push(Transition {
+                                state: separator,
+                                stack_manipulations: vec![stack::Manipulation::Push(
+                                    stack::Value::Return(self),
+                                )],
+                            });
+                        }
+                        for alias in self.aliases {
+                            result.push(Transition {
+                                state: alias.0,
+                                stack_manipulations: vec![stack::Manipulation::Push(
+                                    stack::Value::Return(alias.1),
+                                )],
+                            });
+                            if self.into_repetition {
+                                result.push(Transition {
+                                    state: alias.0,
+                                    stack_manipulations: vec![
+                                        stack::Manipulation::Push(stack::Value::Repetition(self)),
+                                        stack::Manipulation::Push(
+                                            stack::Value::Return(alias.1),
+                                        )],
+                                });
+                            }
+                        }
+                        for grapheme in self.graphemes {
+                            result.push(Transition {
+                                state: grapheme,
+                                stack_manipulations: vec![],
+                            });
+                        }
+    
+                        if matches!(self.r#type, Type::Return | Type::SeparatorReturn) {
+                            if let stack::Value::Return(state) = s {
+                                result.push(Transition {
+                                    state,
+                                    stack_manipulations: vec![stack::Manipulation::Pop],
+                                });
+                            }
                         }
                     }
                 }

--- a/word_filter_codegen/src/pda.rs
+++ b/word_filter_codegen/src/pda.rs
@@ -72,8 +72,7 @@ impl<'a> Pda<'a> {
                     self.states.push(State::default());
                     // Add new state.
                     self.states[index].c_transitions.insert(c, new_index);
-                    // Add repeated transition to new state.
-                    self.states[new_index].repetition = Some(index);
+                    // Add repetition
                     self.states[new_index].into_repetition = true;
                     self.states[new_index].take_repetition = true;
                     // Add separator transition to new state.
@@ -107,8 +106,7 @@ impl<'a> Pda<'a> {
         self.states.push(State::default());
         self.states[index].c_transitions.insert(c, new_index);
         if remaining_g.is_empty() {
-            // Repeating transition.
-            self.states[new_index].repetition = Some(return_index);
+            // Make grapheme transition to repetition.
             self.states[new_index].take_repetition = true;
             // Separator.
             self.states[new_index].into_separator = true;
@@ -270,11 +268,6 @@ impl<'a> Pda<'a> {
                             *transition_index = *replacement_index;
                         }
                     }
-                    if let Some(repetition_index) = state.repetition {
-                        if repetition_index == *deleted_index {
-                            state.repetition = Some(*replacement_index);
-                        }
-                    }
                     let mut new_aliases = BTreeSet::new();
                     for (alias_index, return_index) in state.aliases {
                         let mut new_alias_index = alias_index;
@@ -308,11 +301,6 @@ impl<'a> Pda<'a> {
                     for transition_index in state.c_transitions.values_mut() {
                         if *transition_index > *deleted_index {
                             *transition_index -= 1;
-                        }
-                    }
-                    if let Some(repetition_index) = state.repetition {
-                        if repetition_index > *deleted_index {
-                            state.repetition = Some(repetition_index - 1);
                         }
                     }
                     let mut new_aliases = BTreeSet::new();

--- a/word_filter_codegen/src/pda.rs
+++ b/word_filter_codegen/src/pda.rs
@@ -24,7 +24,10 @@ impl<'a> Pda<'a> {
     pub(crate) fn new() -> Self {
         Self {
             states: vec![
-                State::default(),
+                State {
+                    into_repetition: true,
+                    ..Default::default()
+                },
                 State {
                     r#type: Type::Separator,
                     ..Default::default()
@@ -50,6 +53,7 @@ impl<'a> Pda<'a> {
             let new_index = self.states.len();
             self.states.push(State::default());
             self.states[index].graphemes.insert(new_index);
+            self.states[new_index].into_repetition = true;
             self.add_grapheme(grapheme, graphemes.as_str(), r#type, new_index, new_index);
         } else {
             let mut chars = s.chars();
@@ -70,6 +74,8 @@ impl<'a> Pda<'a> {
                     self.states[index].c_transitions.insert(c, new_index);
                     // Add repeated transition to new state.
                     self.states[new_index].repetition = Some(index);
+                    self.states[new_index].into_repetition = true;
+                    self.states[new_index].take_repetition = true;
                     // Add separator transition to new state.
                     self.states[new_index].into_separator = true;
                     new_index
@@ -103,6 +109,7 @@ impl<'a> Pda<'a> {
         if remaining_g.is_empty() {
             // Repeating transition.
             self.states[new_index].repetition = Some(return_index);
+            self.states[new_index].take_repetition = true;
             // Separator.
             self.states[new_index].into_separator = true;
             // Continue down normal path.
@@ -159,6 +166,7 @@ impl<'a> Pda<'a> {
     pub(crate) fn initialize_alias(&mut self, s: &str) -> usize {
         let new_index = self.states.len();
         self.states.push(State::default());
+        self.states[new_index].into_repetition = true;
         self.add_path(s, Type::Return, new_index);
         new_index
     }

--- a/word_filter_codegen/src/state.rs
+++ b/word_filter_codegen/src/state.rs
@@ -2,7 +2,6 @@
 
 use crate::r#type::Type;
 use alloc::{
-    borrow::ToOwned,
     collections::{BTreeMap, BTreeSet},
     format,
     string::String,
@@ -15,7 +14,6 @@ pub(crate) struct State<'a> {
     pub(crate) r#type: Type<'a>,
     pub(crate) c_transitions: BTreeMap<char, usize>,
     pub(crate) into_separator: bool,
-    pub(crate) repetition: Option<usize>,
     pub(crate) into_repetition: bool,
     pub(crate) take_repetition: bool,
     pub(crate) aliases: BTreeSet<(usize, usize)>,
@@ -30,7 +28,6 @@ impl State<'_> {
                 r#type: {},
                 c_transitions: {},
                 into_separator: {},
-                repetition: {},
                 into_repetition: {},
                 take_repetition: {},
                 aliases: {},
@@ -39,7 +36,6 @@ impl State<'_> {
             self.r#type.to_definition(),
             self.define_c_transition_function(identifier),
             self.into_separator,
-            self.define_repetition(identifier),
             self.into_repetition,
             self.take_repetition,
             self.define_aliases(identifier),
@@ -72,14 +68,6 @@ impl State<'_> {
             identifier,
             index
         )
-    }
-
-    /// Define the repetition transition field.
-    fn define_repetition(&self, identifier: &str) -> String {
-        match self.repetition {
-            Some(index) => format!("Some(&{}.states[{}])", identifier, index),
-            None => "None".to_owned(),
-        }
     }
 
     /// Define the aliases field.

--- a/word_filter_codegen/src/state.rs
+++ b/word_filter_codegen/src/state.rs
@@ -16,6 +16,8 @@ pub(crate) struct State<'a> {
     pub(crate) c_transitions: BTreeMap<char, usize>,
     pub(crate) into_separator: bool,
     pub(crate) repetition: Option<usize>,
+    pub(crate) into_repetition: bool,
+    pub(crate) take_repetition: bool,
     pub(crate) aliases: BTreeSet<(usize, usize)>,
     pub(crate) graphemes: BTreeSet<usize>,
 }
@@ -29,6 +31,8 @@ impl State<'_> {
                 c_transitions: {},
                 into_separator: {},
                 repetition: {},
+                into_repetition: {},
+                take_repetition: {},
                 aliases: {},
                 graphemes: {},
             }}",
@@ -36,6 +40,8 @@ impl State<'_> {
             self.define_c_transition_function(identifier),
             self.into_separator,
             self.define_repetition(identifier),
+            self.into_repetition,
+            self.take_repetition,
             self.define_aliases(identifier),
             self.define_graphemes(identifier),
         )


### PR DESCRIPTION
Fixes #52.

This removes the need to store the state in the repetition field, instead tracking this during computation.

The benefit is huge spatial savings. Since each state is no longer tied to its previous state, the PDA graphs can be reduced tremendously in size during the minimization step. Additionally, removing the extra references decreases compilation time. This is a win all-around.