### PR TITLE
Allow specification of SeparatorFlags.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "word_filter"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Anders Evensen"]
 edition = "2018"
 description = "A Word Filter for filtering text."

--- a/README.md
+++ b/README.md
@@ -38,10 +38,10 @@ First, add both the `word_filter` and `word_filter_codegen` crates to the `Cargo
 
 ``` toml
 [dependencies]
-word_filter = "0.6.0"
+word_filter = "0.7.0"
 
 [build-dependencies]
-word_filter_codegen = "0.6.0"
+word_filter_codegen = "0.7.0"
 ```
 
 Next, generate the `WordFilter` in the `build.rs` file.

--- a/src/censor.rs
+++ b/src/censor.rs
@@ -14,7 +14,7 @@
 //!     io::{BufWriter, Write},
 //!     path::Path,
 //! };
-//! use word_filter_codegen::{Visibility, WordFilterGenerator};
+//! use word_filter_codegen::WordFilterGenerator;
 //!
 //! fn main() {
 //!     let path = Path::new(&env::var("OUT_DIR").unwrap()).join("codegen.rs");
@@ -24,7 +24,6 @@
 //!         &mut file,
 //!         "{}",
 //!         WordFilterGenerator::new()
-//!             .visibility(Visibility::Pub)
 //!             .word("foo")
 //!             .generate("FILTER")
 //!         );
@@ -64,7 +63,7 @@ pub use unicode_segmentation::UnicodeSegmentation;
 ///     io::{BufWriter, Write},
 ///     path::Path,
 /// };
-/// use word_filter_codegen::{Visibility, WordFilterGenerator};
+/// use word_filter_codegen::WordFilterGenerator;
 ///
 /// fn main() {
 ///     let path = Path::new(&env::var("OUT_DIR").unwrap()).join("codegen.rs");
@@ -121,7 +120,7 @@ pub use _replace_graphemes_with as replace_graphemes_with;
 ///     io::{BufWriter, Write},
 ///     path::Path,
 /// };
-/// use word_filter_codegen::{Visibility, WordFilterGenerator};
+/// use word_filter_codegen::WordFilterGenerator;
 ///
 /// fn main() {
 ///     let path = Path::new(&env::var("OUT_DIR").unwrap()).join("codegen.rs");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,6 +82,10 @@ use nested_containment_list::NestedContainmentList;
 use pda::{InstantaneousDescription, State};
 use unicode_segmentation::UnicodeSegmentation;
 
+const WORD_INDEX: usize = 0;
+const EXCEPTION_INDEX: usize = 1;
+const SEPARATOR_INDEX: usize = 2;
+
 /// A word filter for identifying filtered words within strings.
 ///
 /// A `WordFilter` is constructed from **filtered words**, **exceptions**, **separators**,
@@ -113,11 +117,11 @@ impl<'a, const N: usize> WordFilter<'a, N> {
         start: usize,
     ) -> impl Iterator<Item = InstantaneousDescription<'_>> {
         let mut ids = vec![
-            InstantaneousDescription::new(&self.states[0], start),
-            InstantaneousDescription::new(&self.states[1], start),
+            InstantaneousDescription::new(&self.states[WORD_INDEX], start),
+            InstantaneousDescription::new(&self.states[EXCEPTION_INDEX], start),
         ];
-        ids.extend(ids[0].transition(None, &self.states[2], &mut HashSet::new()));
-        ids.extend(ids[1].transition(None, &self.states[2], &mut HashSet::new()));
+        ids.extend(ids[0].transition(None, &self.states[SEPARATOR_INDEX], &mut HashSet::new()));
+        ids.extend(ids[1].transition(None, &self.states[SEPARATOR_INDEX], &mut HashSet::new()));
         ids.into_iter()
     }
 
@@ -134,7 +138,7 @@ impl<'a, const N: usize> WordFilter<'a, N> {
             for c in grapheme.chars() {
                 let mut new_ids = Vec::new();
                 for id in ids.drain(..) {
-                    new_ids.extend(id.step(c, &self.states[2], first_c));
+                    new_ids.extend(id.step(c, &self.states[SEPARATOR_INDEX], first_c));
                 }
                 index += 1;
                 ids = new_ids;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,8 +112,12 @@ impl<'a, const N: usize> WordFilter<'a, N> {
         &'a self,
         start: usize,
     ) -> impl Iterator<Item = InstantaneousDescription<'_>> {
-        let mut ids = vec![InstantaneousDescription::new(&self.states[0], start)];
-        ids.extend(ids[0].transition(None, &self.states[1], &mut HashSet::new()));
+        let mut ids = vec![
+            InstantaneousDescription::new(&self.states[0], start),
+            InstantaneousDescription::new(&self.states[1], start),
+        ];
+        ids.extend(ids[0].transition(None, &self.states[2], &mut HashSet::new()));
+        ids.extend(ids[1].transition(None, &self.states[2], &mut HashSet::new()));
         ids.into_iter()
     }
 
@@ -130,7 +134,7 @@ impl<'a, const N: usize> WordFilter<'a, N> {
             for c in grapheme.chars() {
                 let mut new_ids = Vec::new();
                 for id in ids.drain(..) {
-                    new_ids.extend(id.step(c, &self.states[1], first_c));
+                    new_ids.extend(id.step(c, &self.states[2], first_c));
                 }
                 index += 1;
                 ids = new_ids;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,10 +26,10 @@
 //! ``` toml
 //! ...
 //! [dependencies]
-//! word_filter = "0.6.0"
+//! word_filter = "0.7.0"
 //!
 //! [build-dependencies]
-//! word_filter_codegen = "0.6.0"
+//! word_filter_codegen = "0.7.0"
 //! ...
 //! ```
 //!

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -224,3 +224,8 @@ fn no_separator_allowed_in_exception() {
 fn separators_in_match_but_not_in_exception() {
     assert_eq!(NO_SEPARATOR_IN_EXCEPTION.censor("f o o bar"), "***** bar");
 }
+
+#[test]
+fn empty() {
+    assert_eq!(EMPTY.censor("foo"), "foo");
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -209,3 +209,18 @@ fn do_not_censor_combining_separator_on_other_separator() {
 fn repetition_does_not_match_word() {
     assert_eq!(EXCEPTION.censor("foob"), "***b");
 }
+
+#[test]
+fn no_separator_allowed_in_match() {
+    assert_eq!(NO_SEPARATOR_IN_MATCH.censor("f o o"), "f o o");
+}
+
+#[test]
+fn no_separator_allowed_in_exception() {
+    assert_eq!(NO_SEPARATOR_IN_EXCEPTION.censor("foo bar"), "*** bar");
+}
+
+#[test]
+fn separators_in_match_but_not_in_exception() {
+    assert_eq!(NO_SEPARATOR_IN_EXCEPTION.censor("f o o bar"), "***** bar");
+}

--- a/tests/integration_codegen/build.rs
+++ b/tests/integration_codegen/build.rs
@@ -13,14 +13,11 @@ fn main() {
     let mut base_generator = WordFilterGenerator::new();
     base_generator.visibility(Visibility::Pub);
     let mut foo_generator = base_generator.clone();
-    foo_generator
-        .word("foo");
+    foo_generator.word("foo");
     let mut bar_generator = base_generator.clone();
-    bar_generator
-        .word("bar");
+    bar_generator.word("bar");
     let mut grapheme_generator = base_generator.clone();
-    grapheme_generator
-        .word("bãr");
+    grapheme_generator.word("bãr");
 
     writeln!(
         &mut file,

--- a/tests/integration_codegen/build.rs
+++ b/tests/integration_codegen/build.rs
@@ -4,7 +4,7 @@ use std::{
     io::{BufWriter, Write},
     path::Path,
 };
-use word_filter_codegen::{Visibility, WordFilterGenerator};
+use word_filter_codegen::{SeparatorFlags, Visibility, WordFilterGenerator};
 
 fn main() {
     let file = Path::new(&env::var("OUT_DIR").unwrap()).join("codegen.rs");
@@ -13,15 +13,21 @@ fn main() {
     let mut base_generator = WordFilterGenerator::new();
     base_generator.visibility(Visibility::Pub);
     let mut foo_generator = base_generator.clone();
-    foo_generator.word("foo");
+    foo_generator
+        .separator_flags(SeparatorFlags::BETWEEN_WORDS | SeparatorFlags::BETWEEN_EXCEPTIONS)
+        .word("foo");
     let mut bar_generator = base_generator.clone();
-    bar_generator.word("bar");
+    bar_generator
+        .separator_flags(SeparatorFlags::BETWEEN_WORDS | SeparatorFlags::BETWEEN_EXCEPTIONS)
+        .word("bar");
     let mut grapheme_generator = base_generator.clone();
-    grapheme_generator.word("bãr");
+    grapheme_generator
+        .separator_flags(SeparatorFlags::BETWEEN_WORDS | SeparatorFlags::BETWEEN_EXCEPTIONS)
+        .word("bãr");
 
     writeln!(
         &mut file,
-        "{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}",
+        "{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}",
         foo_generator.generate("WORD"),
         foo_generator.clone().word("bar").generate("MULTIPLE_WORDS"),
         foo_generator
@@ -92,6 +98,18 @@ fn main() {
             .clone()
             .separators(&[' ', '\u{303}'])
             .generate("COMBINING_SEPARATOR"),
+        base_generator
+            .clone()
+            .separator(' ')
+            .word("foo")
+            .generate("NO_SEPARATOR_IN_MATCH"),
+        base_generator
+            .clone()
+            .separator_flags(SeparatorFlags::BETWEEN_WORDS)
+            .separator(" ")
+            .word("foo")
+            .exception("foobar")
+            .generate("NO_SEPARATOR_IN_EXCEPTION"),
     )
     .unwrap();
 }

--- a/tests/integration_codegen/build.rs
+++ b/tests/integration_codegen/build.rs
@@ -27,7 +27,7 @@ fn main() {
 
     writeln!(
         &mut file,
-        "{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}",
+        "{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}",
         foo_generator.generate("WORD"),
         foo_generator.clone().word("bar").generate("MULTIPLE_WORDS"),
         foo_generator
@@ -110,6 +110,7 @@ fn main() {
             .word("foo")
             .exception("foobar")
             .generate("NO_SEPARATOR_IN_EXCEPTION"),
+        base_generator.clone().generate("EMPTY"),
     )
     .unwrap();
 }

--- a/tests/integration_codegen/build.rs
+++ b/tests/integration_codegen/build.rs
@@ -14,15 +14,12 @@ fn main() {
     base_generator.visibility(Visibility::Pub);
     let mut foo_generator = base_generator.clone();
     foo_generator
-        .separator_flags(SeparatorFlags::BETWEEN_WORDS | SeparatorFlags::BETWEEN_EXCEPTIONS)
         .word("foo");
     let mut bar_generator = base_generator.clone();
     bar_generator
-        .separator_flags(SeparatorFlags::BETWEEN_WORDS | SeparatorFlags::BETWEEN_EXCEPTIONS)
         .word("bar");
     let mut grapheme_generator = base_generator.clone();
     grapheme_generator
-        .separator_flags(SeparatorFlags::BETWEEN_WORDS | SeparatorFlags::BETWEEN_EXCEPTIONS)
         .word("bãr");
 
     writeln!(
@@ -100,6 +97,7 @@ fn main() {
             .generate("COMBINING_SEPARATOR"),
         base_generator
             .clone()
+            .separator_flags(SeparatorFlags::empty())
             .separator(' ')
             .word("foo")
             .generate("NO_SEPARATOR_IN_MATCH"),

--- a/word_filter_codegen/Cargo.toml
+++ b/word_filter_codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "word_filter_codegen"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Anders Evensen"]
 edition = "2018"
 description = "Utilities for generating `WordFilter`s at compile-time."

--- a/word_filter_codegen/Cargo.toml
+++ b/word_filter_codegen/Cargo.toml
@@ -12,6 +12,7 @@ keywords = ["wordfilter", "word", "filter", "censor", "string"]
 include = ["/src/**/*", "/LICENSE-*", "/build.rs", "/README.md"]
 
 [dependencies]
+bitflags = "1.2.1"
 hashbrown = "0.11.2"
 new_debug_unreachable = "1.0.4"
 str_overlap = "0.4.3"

--- a/word_filter_codegen/Cargo.toml
+++ b/word_filter_codegen/Cargo.toml
@@ -21,4 +21,4 @@ unicode-segmentation = "1.7.1"
 [dev-dependencies]
 indoc = "1.0.3"
 trybuild = "1.0.42"
-word_filter = {version = "0.6.0", path = ".."}
+word_filter = {version = "0.7.0", path = ".."}

--- a/word_filter_codegen/src/lib.rs
+++ b/word_filter_codegen/src/lib.rs
@@ -544,8 +544,8 @@ impl WordFilterGenerator {
 
         // Apply aliases on root.
         for (value, index) in alias_indices {
-            pda.add_alias(&value, index, 0, &mut BTreeSet::new());
-            pda.add_alias(&value, index, 1, &mut BTreeSet::new());
+            pda.add_alias(&value, index, pda::WORD_INDEX, &mut BTreeSet::new());
+            pda.add_alias(&value, index, pda::EXCEPTION_INDEX, &mut BTreeSet::new());
         }
 
         pda.minimize();

--- a/word_filter_codegen/src/lib.rs
+++ b/word_filter_codegen/src/lib.rs
@@ -146,6 +146,9 @@ bitflags! {
     ///
     /// generator.separator_flags(SeparatorFlags::BETWEEN_WORDS | SeparatorFlags::BETWEEN_EXCEPTIONS);
     /// ```
+    ///
+    /// Note that a `WordFilter` will default to having `BETWEEN_WORDS` and `BETWEEN_EXCEPTIONS`.
+    /// set.
     pub struct SeparatorFlags: u8 {
         /// Allow separators when matching words.
         const BETWEEN_WORDS = 0x0000_0001;
@@ -156,7 +159,7 @@ bitflags! {
 
 impl Default for SeparatorFlags {
     fn default() -> Self {
-        Self::empty()
+        Self::all()
     }
 }
 
@@ -288,9 +291,6 @@ impl WordFilterGenerator {
 
     /// Add a single separator.
     ///
-    /// Note that separator flags must be set with [`separator_flags()`] for this to have any
-    /// effect.
-    ///
     /// # Example
     /// ```
     /// use word_filter_codegen::WordFilterGenerator;
@@ -298,8 +298,6 @@ impl WordFilterGenerator {
     /// let mut generator = WordFilterGenerator::new();
     /// generator.separator("foo");
     /// ```
-    ///
-    /// [`separator_flags()`]: WordFilterGenerator::separator_flags()
     #[inline]
     pub fn separator<S>(&mut self, separator: S) -> &mut Self
     where
@@ -311,9 +309,6 @@ impl WordFilterGenerator {
 
     /// Add separators.
     ///
-    /// Note that separator flags must be set with [`separator_flags()`] for this to have any
-    /// effect.
-    ///
     /// # Example
     /// ```
     /// use word_filter_codegen::WordFilterGenerator;
@@ -321,8 +316,6 @@ impl WordFilterGenerator {
     /// let mut generator = WordFilterGenerator::new();
     /// generator.separators(&["foo", "bar"]);
     /// ```
-    ///
-    /// [`separator_flags()`]: WordFilterGenerator::separator_flags()
     #[inline]
     pub fn separators<I, S>(&mut self, separators: I) -> &mut Self
     where

--- a/word_filter_codegen/src/lib.rs
+++ b/word_filter_codegen/src/lib.rs
@@ -519,25 +519,42 @@ impl WordFilterGenerator {
                 }
             }
         }
-        let mut alias_indices = HashMap::new();
-        for (value, alias) in aliases {
-            let index = alias_indices.entry(value).or_insert(pda.initialize_alias());
-            pda.add_return(*index, &alias);
-        }
 
+        let mut word_alias_indices = HashMap::new();
+        for (value, alias) in &aliases {
+            let index = word_alias_indices.entry(value).or_insert(pda.initialize_alias());
+            pda.add_return(*index, &alias, self.separator_flags.contains(SeparatorFlags::BETWEEN_WORDS));
+        }
         // Apply aliases on each other.
-        for (value, index) in &alias_indices {
-            for (alias_value, alias_index) in &alias_indices {
+        for (value, index) in &word_alias_indices {
+            for (alias_value, alias_index) in &word_alias_indices {
                 if value == alias_value {
                     continue;
                 }
                 pda.add_alias(alias_value, *alias_index, *index, &mut BTreeSet::new());
             }
         }
-
         // Apply aliases on root.
-        for (value, index) in alias_indices {
+        for (value, index) in word_alias_indices {
             pda.add_alias(&value, index, pda::WORD_INDEX, &mut BTreeSet::new());
+        }
+
+        let mut exception_alias_indices = HashMap::new();
+        for (value, alias) in &aliases {
+            let index = exception_alias_indices.entry(value).or_insert(pda.initialize_alias());
+            pda.add_return(*index, &alias, self.separator_flags.contains(SeparatorFlags::BETWEEN_WORDS));
+        }
+        // Apply aliases on each other.
+        for (value, index) in &exception_alias_indices {
+            for (alias_value, alias_index) in &exception_alias_indices {
+                if value == alias_value {
+                    continue;
+                }
+                pda.add_alias(alias_value, *alias_index, *index, &mut BTreeSet::new());
+            }
+        }
+        // Apply aliases on root.
+        for (value, index) in exception_alias_indices {
             pda.add_alias(&value, index, pda::EXCEPTION_INDEX, &mut BTreeSet::new());
         }
 

--- a/word_filter_codegen/src/lib.rs
+++ b/word_filter_codegen/src/lib.rs
@@ -13,10 +13,10 @@
 //! ``` toml
 //! ...
 //! [dependencies]
-//! word_filter = "0.6.0"
+//! word_filter = "0.7.0"
 //!
 //! [build-dependencies]
-//! word_filter_codegen = "0.6.0"
+//! word_filter_codegen = "0.7.0"
 //! ...
 //! ```
 //!

--- a/word_filter_codegen/src/pda.rs
+++ b/word_filter_codegen/src/pda.rs
@@ -7,9 +7,9 @@ use hashbrown::HashMap;
 use unicode_segmentation::UnicodeSegmentation;
 
 // Reserved indices.
-const WORD_INDEX: usize = 0;
-const EXCEPTION_INDEX: usize = 1;
-const SEPARATOR_INDEX: usize = 2;
+pub(crate) const WORD_INDEX: usize = 0;
+pub(crate) const EXCEPTION_INDEX: usize = 1;
+pub(crate) const SEPARATOR_INDEX: usize = 2;
 
 /// Push-down automaton code generator.
 ///

--- a/word_filter_codegen/src/pda.rs
+++ b/word_filter_codegen/src/pda.rs
@@ -271,7 +271,8 @@ impl<'a> Pda<'a> {
             let mut distinct_states = HashMap::new();
             // Note that deleted_states will always be ordered from least to greatest.
             let mut deleted_states = Vec::new();
-            for (index, state) in self.states.iter().cloned().enumerate() {
+            // Skip the reserved indices during merging.
+            for (index, state) in self.states.iter().cloned().enumerate().skip(3) {
                 if let Some(canonical_index) = distinct_states.get(&state) {
                     deleted_states.push((index, *canonical_index));
                 } else {

--- a/word_filter_codegen/src/pda.rs
+++ b/word_filter_codegen/src/pda.rs
@@ -7,8 +7,9 @@ use hashbrown::HashMap;
 use unicode_segmentation::UnicodeSegmentation;
 
 // Reserved indices.
-const ENTRY_INDEX: usize = 0;
-const SEPARATOR_INDEX: usize = 1;
+const WORD_INDEX: usize = 0;
+const EXCEPTION_INDEX: usize = 1;
+const SEPARATOR_INDEX: usize = 2;
 
 /// Push-down automaton code generator.
 ///
@@ -24,10 +25,17 @@ impl<'a> Pda<'a> {
     pub(crate) fn new() -> Self {
         Self {
             states: vec![
+                // Word entry state.
                 State {
                     into_repetition: true,
                     ..Default::default()
                 },
+                // Exception entry state.
+                State {
+                    into_repetition: true,
+                    ..Default::default()
+                },
+                // Separator entry state.
                 State {
                     r#type: Type::Separator,
                     ..Default::default()
@@ -37,7 +45,7 @@ impl<'a> Pda<'a> {
     }
 
     /// Add a path along input `s`, ending with state of the specified type.
-    fn add_path(&mut self, s: &str, r#type: Type<'a>, index: usize) {
+    fn add_path(&mut self, s: &str, r#type: Type<'a>, index: usize, into_separator: bool) {
         let mut graphemes = s.graphemes(true);
         let grapheme = match graphemes.next() {
             Some(g) => g,
@@ -54,7 +62,14 @@ impl<'a> Pda<'a> {
             self.states.push(State::default());
             self.states[index].graphemes.insert(new_index);
             self.states[new_index].into_repetition = true;
-            self.add_grapheme(grapheme, graphemes.as_str(), r#type, new_index, new_index);
+            self.add_grapheme(
+                grapheme,
+                graphemes.as_str(),
+                r#type,
+                new_index,
+                new_index,
+                into_separator,
+            );
         } else {
             let mut chars = s.chars();
             let c = match chars.next() {
@@ -76,12 +91,12 @@ impl<'a> Pda<'a> {
                     self.states[new_index].into_repetition = true;
                     self.states[new_index].take_repetition = true;
                     // Add separator transition to new state.
-                    self.states[new_index].into_separator = true;
+                    self.states[new_index].into_separator = into_separator;
                     new_index
                 }
             };
 
-            self.add_path(chars.as_str(), r#type, new_index)
+            self.add_path(chars.as_str(), r#type, new_index, into_separator)
         }
     }
 
@@ -95,6 +110,7 @@ impl<'a> Pda<'a> {
         r#type: Type<'a>,
         index: usize,
         return_index: usize,
+        into_separator: bool,
     ) {
         let mut chars = g.chars();
         let c = match chars.next() {
@@ -109,24 +125,31 @@ impl<'a> Pda<'a> {
             // Make grapheme transition to repetition.
             self.states[new_index].take_repetition = true;
             // Separator.
-            self.states[new_index].into_separator = true;
+            self.states[new_index].into_separator = into_separator;
             // Continue down normal path.
-            self.add_path(s, r#type, new_index);
+            self.add_path(s, r#type, new_index, into_separator);
         } else {
-            self.add_grapheme(remaining_g, s, r#type, new_index, return_index);
+            self.add_grapheme(
+                remaining_g,
+                s,
+                r#type,
+                new_index,
+                return_index,
+                into_separator,
+            );
         }
     }
 
     /// Add a word.
     #[inline]
-    pub(crate) fn add_word(&mut self, s: &'a str) {
-        self.add_path(s, Type::Word(s), ENTRY_INDEX)
+    pub(crate) fn add_word(&mut self, s: &'a str, into_separator: bool) {
+        self.add_path(s, Type::Word(s), WORD_INDEX, into_separator)
     }
 
     /// Add an exception.
     #[inline]
-    pub(crate) fn add_exception(&mut self, s: &str) {
-        self.add_path(s, Type::Exception, ENTRY_INDEX)
+    pub(crate) fn add_exception(&mut self, s: &str, into_separator: bool) {
+        self.add_path(s, Type::Exception, EXCEPTION_INDEX, into_separator)
     }
 
     /// Add separator states using input `s`.
@@ -169,7 +192,7 @@ impl<'a> Pda<'a> {
     }
 
     pub(crate) fn add_return(&mut self, index: usize, s: &str) {
-        self.add_path(s, Type::Return, index)
+        self.add_path(s, Type::Return, index, true)
     }
 
     /// Find the return states for defining an alias along the input `s`.

--- a/word_filter_codegen/src/pda.rs
+++ b/word_filter_codegen/src/pda.rs
@@ -191,8 +191,8 @@ impl<'a> Pda<'a> {
         new_index
     }
 
-    pub(crate) fn add_return(&mut self, index: usize, s: &str) {
-        self.add_path(s, Type::Return, index, true)
+    pub(crate) fn add_return(&mut self, index: usize, s: &str, into_separator: bool) {
+        self.add_path(s, Type::Return, index, into_separator)
     }
 
     /// Find the return states for defining an alias along the input `s`.

--- a/word_filter_codegen/tests/trybuild.rs
+++ b/word_filter_codegen/tests/trybuild.rs
@@ -4,7 +4,7 @@ use std::{
     fs::File,
     io::{BufWriter, Write},
 };
-use word_filter_codegen::{Visibility, WordFilterGenerator};
+use word_filter_codegen::{SeparatorFlags, Visibility, WordFilterGenerator};
 
 macro_rules! compiles {
     ($test_name:ident, $generator:expr) => {
@@ -127,3 +127,4 @@ compiles!(
         bar"
     ))
 );
+compiles!(separator_flags, WordFilterGenerator::new().separator_flags(SeparatorFlags::BETWEEN_EXCEPTIONS));

--- a/word_filter_codegen/tests/trybuild.rs
+++ b/word_filter_codegen/tests/trybuild.rs
@@ -127,4 +127,7 @@ compiles!(
         bar"
     ))
 );
-compiles!(separator_flags, WordFilterGenerator::new().separator_flags(SeparatorFlags::BETWEEN_EXCEPTIONS));
+compiles!(
+    separator_flags,
+    WordFilterGenerator::new().separator_flags(SeparatorFlags::BETWEEN_EXCEPTIONS)
+);


### PR DESCRIPTION
This PR introduces `SeparatorFlags` in the codegen crate, allowing users to specify how separators should be applied in the generated automaton.